### PR TITLE
docs: add historical context and word of warning (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ console.log(someLargeStringToOutput)
 
 ## Historical Context/Word of Warning
 
-This shim was created as a shim to address the bug discussed in [node #6456](https://github.com/nodejs/node/issues/6456). This bug crops up on
+This was created as a shim to address the bug discussed in [node #6456](https://github.com/nodejs/node/issues/6456). This bug crops up on
 newer versions of Node.js (`0.12+`). You should be mindful of the side-effects
 caused by `set-blocking`:
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ console.log(someLargeStringToOutput)
 ## Historical Context/Word of Warning
 
 This was created as a shim to address the bug discussed in [node #6456](https://github.com/nodejs/node/issues/6456). This bug crops up on
-newer versions of Node.js (`0.12+`). You should be mindful of the side-effects
-caused by `set-blocking`:
+newer versions of Node.js (`0.12+`), truncating terminal output.
+
+You should be mindful of the side-effects caused by using `set-blocking`:
 
 * if your module sets blocking to `true`, it will effect other modules
   consuming your library. In [yargs](https://github.com/yargs/yargs/blob/master/yargs.js#L653) we only call

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ setBlocking(true)
 console.log(someLargeStringToOutput)
 ```
 
+## Historical Context/Word of Warning
+
+This shim was created as a shim to address the bug discussed in [node #6456](https://github.com/nodejs/node/issues/6456). This bug crops up on
+newer versions of Node.js (`0.12+`). You should be mindful of the side-effects
+caused by `set-blocking`:
+
+* if your module sets blocking to `true`, it will effect other modules
+  consuming your library. In [yargs](https://github.com/yargs/yargs/blob/master/yargs.js#L653) we only call
+  `setBlocking(true)` once we already know we are about to call `process.exit(code)`.
+* this patch will not apply to subprocesses spawned with `isTTY = true`, this is
+  the [default `spawn()` behavior](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+
 ## License
 
 ISC


### PR DESCRIPTION
add warning and historical context, fixes #2 
