### PR TITLE
chore: update travis config with node LTS & stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ os:
 after_success: npm run coverage
 
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
-  - "node"
+  - "6"
+  - "stable"


### PR DESCRIPTION
Since node < 4 is no longer supported and v5 is past its useful life.